### PR TITLE
Fix: add transparent border color to inactive nav items

### DIFF
--- a/style.css
+++ b/style.css
@@ -403,12 +403,13 @@ a {
   background-color: rgba(46, 46, 46, 0.1);
   padding: 5px 15px;
   border-radius: 10px;
-  border: none;
+  border: 2px solid transparent;
   outline: none;
   cursor: pointer;
+  transition: border-color 0.25s ease-in-out;
 }
 #regionSelect span:hover {
-  border: 2px solid #202020;
+  border-color: #202020;
 }
 
 ::-webkit-scrollbar {


### PR DESCRIPTION
This fixes a bug when the layout would shift slightly while hovering over the navigation item. I also added a transition to make this look smoother.