### PR TITLE
fixes #45 - spinning effect on pokeball added

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5501
+}

--- a/style.css
+++ b/style.css
@@ -203,7 +203,8 @@ h1 {
 .nav.github,
 a:hover {
   color: #310d15;
-  font-size: 1.8em;
+  transform: scale(1.2);
+  transition: color 0.2s, transform 0.2s;
 }
 
 .header {
@@ -223,6 +224,15 @@ a:hover {
   width: 50px;
   height: 50px;
   cursor: pointer;
+}
+
+.logo {
+  display: inline-block;
+  transition: transform 0.6s;
+}
+
+.logo:hover {
+  transform: rotate(360deg); 
 }
 
 .nav .github,
@@ -526,8 +536,13 @@ a {
 
 .features{
   display: flex;
+  justify-content: space-around;
+  align-items: center;
 }
 
+#dark:hover {
+  cursor: pointer;
+}
 
 .darkmode-container{
   margin-right: 2.5em;
@@ -542,17 +557,17 @@ a {
   display: flex;
 }
 
-.darkmode-button-icon{
-  cursor: pointer;
-  margin-top: 0.1em;
-}
 
 .darkmode-text{
   margin-right: 0.3em;
 }
 
-.github{
-  margin-top: 0.15em;
+.github {
+  min-height: 2rem;
+  min-width: 2rem;
+  display: flex;
+  align-items: center; 
+  justify-content: center; 
 }
 
 .dark-mode {


### PR DESCRIPTION
Required spinning effect added.

features added:
1. pokeball spin animation on hover.
2. github icon transition on hover smoothened.
3. minor bug fix - on github hover, headers elements shifted left, bug fixed.