### PR TITLE
fixed search bar and logo moving on mobile scroll

### DIFF
--- a/style.css
+++ b/style.css
@@ -291,10 +291,6 @@ a {
 
 }
 
-.box{
-  position: fixed;
-}
-
 .box input {
   width: 100%;
   height: 50px;
@@ -593,7 +589,7 @@ a {
 .dark-mode #regionSelect span {
   border: 1px solid #ccc; 
 }
-
+relative
 .dark-mode #regionSelect span:hover{
   color: black;
   background-color: #ead51d;
@@ -609,7 +605,7 @@ a {
     padding-top: 35px;
   }
   .logo {
-    position: fixed;
+    position: absolute;
     left: 10px;
   }
 


### PR DESCRIPTION
I noticed after the merge of #52 that the search bar and logo were moving with scroll on my phone as seen here:

https://github.com/lazyjinchuriki/pokedex/assets/18507739/fa9ddf0a-9c63-4241-a44d-2b25ca4939ef

This commit resolves this issue.

https://github.com/lazyjinchuriki/pokedex/assets/18507739/c7a3aa72-f68b-4dcc-bf15-f534ecc4255b

