### PR TITLE
[Fix: #56] Disable hover effect on touchscreen device

### DIFF
--- a/style.css
+++ b/style.css
@@ -102,6 +102,18 @@ h1 {
   transition-delay: .2s;
 }
 
+/* Handle card flip behavior on touch-screen */
+@media(hover: none) {
+  .cardContainer:hover .card {
+    transform: none;
+    transition: none;
+  }
+
+  .back {
+    visibility: hidden;
+  }
+}
+
 .types {
   display: flex;
 }


### PR DESCRIPTION
Closes #56.

The behavior described in the issue is caused on touch-screen devices which cannot hover over elements. I attempted adding a flip button to each card, but I just felt this didn't look right. So, I think the best action is to just disable the card flip behavior on touch-screen devices since the same info can be seen when tapping on the card. However, someone in the future might want to display the back-side of the pokemon image on the pokemon details page.